### PR TITLE
Add support for Cake 5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.4', '8.0', '8.1']
+        php-version: ['8.1']
         db-type: [sqlite, mysql]
     name: PHP ${{ matrix.php-version }}
 
@@ -38,12 +38,7 @@ jobs:
 
     - name: composer install
       run: |
-        if [[ ${{ matrix.php-version }} == '8.0' ]]; then
-          composer install --ignore-platform-reqs
-        else
-          composer install
-        fi
-        composer run-script post-install-cmd --no-interaction
+        composer install
 
     - name: Run PHPUnit
       run: |
@@ -63,7 +58,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '8.1'
         extensions: mbstring, intl
         coverage: none
 
@@ -85,12 +80,12 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-        php-version: '7.4'
+        php-version: '8.1'
         extensions: mbstring, intl
         coverage: none
 
     - name: composer install
-      run: composer require --dev phpstan/phpstan:^1.2
+      run: composer require --dev phpstan/phpstan:^1.9
 
     - name: Run phpstan
       run: vendor/bin/phpstan.phar analyse

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Thumbs.db
 composer.lock
 # PHPUnit
 .phpunit.result.cache
+.phpunit.cache
 # vim
 *~
 *.swp

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ This plugin will automatically generate a working title using values such as the
 You can set our own format by configuring the Component when loading it in your application.
 
 ## Version map:
-| Plugin | Branch | Cake | PHP |
-|--------| ------ | --- | --- |
-| 2.x    | main | 5.x | ^8.1 |
-| 1.x    | 1.x | 4.x | ^7.4 \| ^8.0 |
+| Plugin | Branch | Cake | PHP          |
+|--------|--------|------|--------------|
+| 2.x    | main   | 5.x  | ^8.1         |
+| 1.x    | 1.x    | 4.x  | ^7.4 \| ^8.0 |
 
 ### Configuration options:
 * `format` - How the generated title should be formatted. See valid placeholders below.
@@ -29,7 +29,7 @@ You can set our own format by configuring the Component when loading it in your 
 * `action` - Will be replaced by the requested action
 * `prefix` - Will be replaced by the requested prefix, if there is one.
 * `displayField` - If your action stores an entity variable in the view, the component attempts to get the entity's display field value to display in the title
-    * For example: If you have a table called Tools and the display field is the tool's name, if will place the tool's name in the title.
+    * For example: If you have a table called Tools and the display field is the tool's name, it will place the tool's name in the title.
     * The display field value is not fetched on its own from the database. It attempts to find a view var in which to get the value from.
     * Please note that the entity variable must be named using cake's convention. A Tool entity variable must be `$tool`. A FilesType entity must be named `$filesType`.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ This plugin will automatically generate a working title using values such as the
 
 You can set our own format by configuring the Component when loading it in your application.
 
+## Version map:
+| Plugin | Branch | Cake | PHP |
+|--------| ------ | --- | --- |
+| 2.x    | main | 5.x | ^8.1 |
+| 1.x    | 1.x | 4.x | ^7.4 \| ^8.0 |
+
 ### Configuration options:
 * `format` - How the generated title should be formatted. See valid placeholders below.
     * Default format: `{{prefix} - }{{controller} - }{{action} - }{{displayField}}{ &raquo; {appName}}`

--- a/composer.json
+++ b/composer.json
@@ -6,24 +6,30 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "cakephp/cakephp": "^5.x-dev@dev"
+        "cakephp/cakephp": "^5.0.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^5.0",
-        "phpunit/phpunit": "^9.5",
-        "phpstan/phpstan": "^1.9"
+        "phpunit/phpunit": "^10.1.0",
+        "phpstan/phpstan": "^1.10.33"
     },
     "autoload": {
         "psr-4": {
             "Avolle\\Title\\": "src"
-        }
+        },
+        "files": [
+            "vendor/cakephp/cakephp/src/functions.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {
             "Avolle\\Title\\Test\\": "tests",
             "Avolle\\Title\\Test\\Fixture\\": "tests",
             "TestApp\\": "tests/test_app/TestApp"
-        }
+        },
+        "files": [
+            "vendor/cakephp/cakephp/src/functions.php"
+        ]
     },
     "scripts": {
         "check": [

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "test": "phpunit --colors=always"
     },
     "prefer-stable": true,
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -16,20 +16,14 @@
     "autoload": {
         "psr-4": {
             "Avolle\\Title\\": "src"
-        },
-        "files": [
-            "vendor/cakephp/cakephp/src/functions.php"
-        ]
+        }
     },
     "autoload-dev": {
         "psr-4": {
             "Avolle\\Title\\Test\\": "tests",
             "Avolle\\Title\\Test\\Fixture\\": "tests",
             "TestApp\\": "tests/test_app/TestApp"
-        },
-        "files": [
-            "vendor/cakephp/cakephp/src/functions.php"
-        ]
+        }
     },
     "scripts": {
         "check": [

--- a/composer.json
+++ b/composer.json
@@ -5,12 +5,12 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": ">=7.4",
-        "cakephp/cakephp": "^4.2"
+        "php": "^8.1",
+        "cakephp/cakephp": "^5.x-dev@dev"
     },
     "require-dev": {
-        "cakephp/cakephp-codesniffer": "^4.2",
-        "phpunit/phpunit": "~8.5.0 || ^9.3",
+        "cakephp/cakephp-codesniffer": "^5.0",
+        "phpunit/phpunit": "^9.5",
         "phpstan/phpstan": "^1.9"
     },
     "autoload": {
@@ -36,6 +36,7 @@
         "test": "phpunit --colors=always"
     },
     "prefer-stable": true,
+    "minimum-stability": "dev",
     "config": {
         "sort-packages": true,
         "allow-plugins": {

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,3 +1,3 @@
 <?php
 
-require CAKE . 'functions.php';
+require CAKE . 'src/functions.php';

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+
+require CAKE . 'functions.php';

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,3 +1,3 @@
 <?php
 
-require CAKE . 'src/functions.php';
+// Left empty

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,3 +5,5 @@ parameters:
     treatPhpDocTypesAsCertain: false
     paths:
         - src
+    bootstrapFiles:
+        - tests/bootstrap.php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,13 +5,10 @@
     processIsolation="false"
     stopOnFailure="false"
     bootstrap="./tests/bootstrap.php"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    cacheDirectory=".phpunit.cache"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.3/phpunit.xsd"
 >
-    <coverage>
-        <include>
-            <directory suffix=".php">./src/</directory>
-        </include>
-    </coverage>
+    <coverage/>
     <php>
         <ini name="memory_limit" value="-1"/>
         <ini name="apc.enable_cli" value="1"/>
@@ -23,6 +20,11 @@
         </testsuite>
     </testsuites>
     <extensions>
-        <extension class="\Cake\TestSuite\Fixture\PHPUnitExtension" />
+        <bootstrap class="Cake\TestSuite\Fixture\Extension\PHPUnitExtension" />
     </extensions>
+    <source>
+        <include>
+            <directory suffix=".php">./src/</directory>
+        </include>
+    </source>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,14 +22,7 @@
             <directory>./tests/TestCase</directory>
         </testsuite>
     </testsuites>
-    <!-- Setup a listener for fixtures -->
-    <listeners>
-        <listener
-            class="\Cake\TestSuite\Fixture\FixtureInjector"
-            file="./vendor/cakephp/cakephp/src/TestSuite/Fixture/FixtureInjector.php">
-            <arguments>
-                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
-            </arguments>
-        </listener>
-    </listeners>
+    <extensions>
+        <extension class="\Cake\TestSuite\Fixture\PHPUnitExtension" />
+    </extensions>
 </phpunit>

--- a/src/Controller/Component/TitleComponent.php
+++ b/src/Controller/Component/TitleComponent.php
@@ -23,15 +23,15 @@ class TitleComponent extends Component
      *    - {{appName}}: Replaced with the application's name
      *    - {{prefix}}: Replaced with the requested prefix (eg. Admin)
      *    - {{controller}}: Replaced with the requested controller (eg. Users)
-     *    - {{action}}: Replaced with the requested action (eg. View). If option ignoreIndex is true, the placeholder will be omitted.
-     *    - {{displayField}}: Replaced with the requested controller's related model's display field (eg. name from the UsersTable)
+     *    - {{action}}: Replaced with the requested action (e.g. View). If option ignoreIndex is true, the placeholder will be omitted.
+     *    - {{displayField}}: Replaced with the requested controller's related model's display field (e.g. name from the UsersTable)
      * - appName: Your application's name (human friendly)
      * - ignoreIndex : Whether to omit the controller action in the format if the requested action is index
      * - showDisplayFieldOnView : Whether to append the displayField when the requested controller action is view
      *
      * @var array<string, mixed>
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'appName' => '',
         'format' => '{{prefix} - }{{controller} - }{{action} - }{{displayField}}{ &raquo; {appName}}',
         'ignoreIndex' => false,
@@ -127,15 +127,15 @@ class TitleComponent extends Component
      * Get the Controller guesstimated related Model Class' Display Field
      *
      * @param string $model Model go get display field from
-     * @return string|string[]|null
+     * @return array<string>|string|null
      */
-    protected function getDisplayField(string $model)
+    protected function getDisplayField(string $model): array|string|null
     {
         return $this->getController()->getTableLocator()->get($model)->getDisplayField();
     }
 
     /**
-     * Return a "view var" guesstimated compatible string. Eg. Referees will return referee
+     * Return a "view var" guesstimated compatible string. E.g. Referees will return referee
      *
      * @param string $model Model to inflect
      * @return string
@@ -193,7 +193,7 @@ class TitleComponent extends Component
      */
     protected function replaceAttribute(string $attribute, string $replacement, string $title): string
     {
-        $isSpecialAttribute = strpos($title, '{{' . $attribute . '}}') === false;
+        $isSpecialAttribute = !str_contains($title, '{{' . $attribute . '}}');
 
         if (!$isSpecialAttribute) {
             return str_replace('{{' . $attribute . '}}', $replacement, $title);

--- a/tests/Fixture/FilesTypesFixture.php
+++ b/tests/Fixture/FilesTypesFixture.php
@@ -11,25 +11,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class FilesTypesFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // phpcs:disable
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => null, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
-        'name' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null],
-        'title' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'latin1_swedish_ci'
-        ],
-    ];
-    // phpcs:enable
-    /**
      * Init method
      *
      * @return void

--- a/tests/Fixture/LocationsFixture.php
+++ b/tests/Fixture/LocationsFixture.php
@@ -11,25 +11,6 @@ use Cake\TestSuite\Fixture\TestFixture;
 class LocationsFixture extends TestFixture
 {
     /**
-     * Fields
-     *
-     * @var array
-     */
-    // @codingStandardsIgnoreStart
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => null, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
-        'name' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null],
-        'city' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'collate' => 'latin1_swedish_ci', 'comment' => '', 'precision' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'latin1_swedish_ci'
-        ],
-    ];
-    // @codingStandardsIgnoreEnd
-    /**
      * Init method
      *
      * @return void

--- a/tests/Fixture/MonitoringFixture.php
+++ b/tests/Fixture/MonitoringFixture.php
@@ -15,26 +15,8 @@ class MonitoringFixture extends TestFixture
      *
      * @var string
      */
-    public $table = 'monitoring';
+    public string $table = 'monitoring';
 
-    /**
-     * Fields
-     *
-     * @var array
-     */
-    // phpcs:disable
-    public $fields = [
-        'id' => ['type' => 'integer', 'length' => null, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
-        'comment' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'collate' => 'latin1_swedish_ci', 'precision' => null],
-        '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
-        ],
-        '_options' => [
-            'engine' => 'InnoDB',
-            'collation' => 'latin1_swedish_ci'
-        ],
-    ];
-    // phpcs:enable
     /**
      * Init method
      *

--- a/tests/TestCase/Controller/Component/TitleComponentIntegrationTest.php
+++ b/tests/TestCase/Controller/Component/TitleComponentIntegrationTest.php
@@ -22,9 +22,9 @@ class TitleComponentIntegrationTest extends TestCase
     /**
      * Fixtures
      *
-     * @var array
+     * @var string[]
      */
-    public $fixtures = [
+    public array $fixtures = [
         'plugin.Avolle/Title.FilesTypes',
         'plugin.Avolle/Title.Locations',
         'plugin.Avolle/Title.Monitoring',

--- a/tests/TestCase/Controller/Component/TitleComponentTest.php
+++ b/tests/TestCase/Controller/Component/TitleComponentTest.php
@@ -35,7 +35,8 @@ class TitleComponentTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-        $this->registry = new ComponentRegistry(new LocationsController());
+        $request = new ServerRequest();
+        $this->registry = new ComponentRegistry(new LocationsController($request));
         $this->Title = new TitleComponent($this->registry);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 declare(strict_types=1);
 
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
@@ -40,7 +41,6 @@ define('CAKE_CORE_INCLUDE_PATH', ROOT . '/vendor/cakephp/cakephp');
 define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
 define('CAKE', CORE_PATH . 'src' . DS);
 
-require ROOT . '/vendor/cakephp/cakephp/src/basics.php';
 require ROOT . '/vendor/autoload.php';
 
 Configure::write('debug', true);
@@ -68,7 +68,7 @@ if (!getenv('db_dsn')) {
     putenv('db_dsn=sqlite:///:memory:');
 }
 
-Cake\Datasource\ConnectionManager::setConfig('test', [
+ConnectionManager::setConfig('test', [
     'url' => getenv('db_dsn'),
     'username' => 'root',
     'password' => 'root',
@@ -106,7 +106,7 @@ $cache = [
     ],
 ];
 
-Cake\Cache\Cache::setConfig($cache);
+Cache::setConfig($cache);
 
 session_id('cli');
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,6 +41,7 @@ define('CAKE_CORE_INCLUDE_PATH', ROOT . '/vendor/cakephp/cakephp');
 define('CORE_PATH', CAKE_CORE_INCLUDE_PATH . DS);
 define('CAKE', CORE_PATH . 'src' . DS);
 
+require ROOT . '/vendor/cakephp/cakephp/src/functions.php';
 require ROOT . '/vendor/autoload.php';
 
 Configure::write('debug', true);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,7 +5,7 @@ use Cake\Core\Configure;
 use Cake\Database\Connection;
 use Cake\Database\Driver\Sqlite;
 use Cake\Datasource\ConnectionManager;
-use Cake\Filesystem\Folder;
+use Cake\TestSuite\Fixture\SchemaLoader;
 
 $findRoot = function ($root) {
     do {
@@ -86,11 +86,6 @@ Cake\Datasource\ConnectionManager::setConfig('test', [
 
 ConnectionManager::alias('test', 'default');
 
-$tmp = new Folder(TMP);
-$tmp->create(TMP . 'cache/models', 0777);
-$tmp->create(TMP . 'cache/persistent', 0777);
-$tmp->create(TMP . 'cache/views', 0777);
-
 $cache = [
     'default' => [
         'engine' => 'File',
@@ -114,3 +109,5 @@ $cache = [
 Cake\Cache\Cache::setConfig($cache);
 
 session_id('cli');
+
+(new SchemaLoader())->loadSqlFiles(ROOT . DS . 'tests' . DS . 'schema.sql');

--- a/tests/schema.sql
+++ b/tests/schema.sql
@@ -1,0 +1,22 @@
+CREATE TABLE `files_types`
+(
+    `id`      INT          NULL,
+    `name` VARCHAR(255) NULL DEFAULT NULL,
+    `title` VARCHAR(255) NULL DEFAULT NULL,
+    PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `locations`
+(
+    `id`      INT          NULL,
+    `name` VARCHAR(255) NULL DEFAULT NULL,
+    `city` VARCHAR(255) NULL DEFAULT NULL,
+    PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `monitoring`
+(
+    `id`      INT          NULL,
+    `title` VARCHAR(255) NULL DEFAULT NULL,
+    PRIMARY KEY (`id`)
+);

--- a/tests/test_app/TestApp/Controller/AppController.php
+++ b/tests/test_app/TestApp/Controller/AppController.php
@@ -42,7 +42,6 @@ class AppController extends Controller
     {
         parent::initialize();
 
-        $this->loadComponent('RequestHandler', ['enableBeforeRedirect' => false]);
         $this->loadComponent('Flash');
         $this->loadComponent('Avolle/Title.Title');
     }

--- a/tests/test_app/TestApp/Model/Entity/FilesType.php
+++ b/tests/test_app/TestApp/Model/Entity/FilesType.php
@@ -19,9 +19,9 @@ class FilesType extends Entity
      * be mass assigned. For security purposes, it is advised to set '*' to false
      * (or remove it), and explicitly make individual fields accessible as needed.
      *
-     * @var array
+     * @var array<string, bool>
      */
-    protected $_accessible = [
+    protected array $_accessible = [
         'name' => true,
     ];
 }

--- a/tests/test_app/TestApp/Model/Entity/Location.php
+++ b/tests/test_app/TestApp/Model/Entity/Location.php
@@ -22,9 +22,9 @@ class Location extends Entity
      * be mass assigned. For security purposes, it is advised to set '*' to false
      * (or remove it), and explicitly make individual fields accessible as needed.
      *
-     * @var array
+     * @var array<string, bool>
      */
-    protected $_accessible = [
+    protected array $_accessible = [
         'name' => true,
         'address' => true,
         'postCode' => true,

--- a/tests/test_app/TestApp/Model/Entity/Monitoring.php
+++ b/tests/test_app/TestApp/Model/Entity/Monitoring.php
@@ -21,9 +21,9 @@ class Monitoring extends Entity
      * be mass assigned. For security purposes, it is advised to set '*' to false
      * (or remove it), and explicitly make individual fields accessible as needed.
      *
-     * @var array
+     * @var array<string, bool>
      */
-    protected $_accessible = [
+    protected array $_accessible = [
         'onLoan' => true,
         'onReturn' => true,
         'comment' => true,

--- a/tests/test_app/config/bootstrap.php
+++ b/tests/test_app/config/bootstrap.php
@@ -1,2 +1,3 @@
 <?php
-// Do nothing
+
+require 'config/bootstrap.php';


### PR DESCRIPTION
This PR adds support for CakePHP 5.x.

Changes: 
* Moved away from the deprecated Fixture system and uses the new one.
* Adding types to properties and parameters.