### PR TITLE
Fix display field not working when using non-default table in controller

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,7 +1,5 @@
 parameters:
     level: 7
-    checkGenericClassInNonGenericObjectType: false
-    checkMissingIterableValueType: false
     treatPhpDocTypesAsCertain: false
     paths:
         - src

--- a/src/Controller/Component/TitleComponent.php
+++ b/src/Controller/Component/TitleComponent.php
@@ -105,7 +105,7 @@ class TitleComponent extends Component
      */
     protected function getDisplayFieldValue(): string
     {
-        $model = $this->getController()->getName();
+        $model = $this->getController()->fetchTable()->getAlias();
         $entityVar = $this->getEntityVar($model);
         $entity = $this->getEntity($entityVar);
         if (is_null($entity)) {

--- a/src/Controller/Component/TitleComponent.php
+++ b/src/Controller/Component/TitleComponent.php
@@ -117,7 +117,7 @@ class TitleComponent extends Component
             return '';
         }
         if (is_array($displayField)) {
-            return implode(' - ', array_map(fn ($field) => (string)$entity->get($field), $displayField));
+            return implode(' - ', array_map(fn($field) => (string)$entity->get($field), $displayField));
         }
 
         return (string)$entity->get($displayField);

--- a/src/Controller/Component/TitleComponent.php
+++ b/src/Controller/Component/TitleComponent.php
@@ -42,7 +42,7 @@ class TitleComponent extends Component
      * If title not already set in the action, create and set a title based on controller, controller action and
      * controller related model class' display field (if action is view and option showDisplayFieldOnView is true
      *
-     * @param \Cake\Event\Event $event Event
+     * @param \Cake\Event\Event<\Cake\Controller\Controller> $event Event
      * @return void
      * @noinspection PhpUnusedParameterInspection
      */

--- a/tests/TestCase/Controller/Component/TitleComponentIntegrationTest.php
+++ b/tests/TestCase/Controller/Component/TitleComponentIntegrationTest.php
@@ -121,6 +121,21 @@ class TitleComponentIntegrationTest extends TestCase
     }
 
     /**
+     * Test testTitleWithNonDefaultTableName method
+     *
+     * If you have a controller that changes the `defaultTable` property, then this test will assert that works OK
+     *
+     * @return void
+     * @covers \Avolle\Title\Controller\Component\TitleComponent::formatTitle()
+     */
+    public function testTitleWithNonDefaultTableName(): void
+    {
+        $expected = '<title>Locations Aliases - View - Ålesund</title>';
+        $this->get(['controller' => 'LocationsAliases', 'action' => 'view', 1]);
+        $this->assertTitle($expected);
+    }
+
+    /**
      * Assert that title is set as expected
      * Will show actual title if assertion is wrong
      *

--- a/tests/TestCase/Controller/Component/TitleComponentIntegrationTest.php
+++ b/tests/TestCase/Controller/Component/TitleComponentIntegrationTest.php
@@ -144,7 +144,7 @@ class TitleComponentIntegrationTest extends TestCase
      */
     protected function assertTitle(string $expected): void
     {
-        preg_match('/<title>.*?<\/title>/', (string)$this->_response, $matches);
+        preg_match('/<title>.*?<\/title>/', $this->_getBodyAsString(), $matches);
         $this->assertResponseContains($expected, 'Actual title: ' . ($matches[0] ?? 'No title found'));
     }
 }

--- a/tests/test_app/TestApp/Controller/LocationsAliasesController.php
+++ b/tests/test_app/TestApp/Controller/LocationsAliasesController.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace TestApp\Controller;
+
+/**
+ * LocationsAliases Controller
+ *
+ * @property \TestApp\Model\Table\LocationsTable $Locations
+ * @method \TestApp\Model\Entity\Location[]|\Cake\Datasource\ResultSetInterface paginate($object = null, array $settings = [])
+ * @noinspection PhpFullyQualifiedNameUsageInspection
+ */
+class LocationsAliasesController extends AppController
+{
+    /**
+     * @inheritDoc
+     */
+    protected ?string $defaultTable = 'Locations';
+
+    /**
+     * View method
+     *
+     * @param string|null $id Location id.
+     * @return \Cake\Http\Response|void
+     * @throws \Cake\Datasource\Exception\RecordNotFoundException When record not found.
+     */
+    public function view($id = null)
+    {
+        $location = $this->Locations->get($id);
+
+        $this->set('location', $location);
+    }
+}


### PR DESCRIPTION
When there's a controller that uses the non-conventional name, one needs to use the `defaultTable` property to override what model is fetched in the controller. In this scenario, the display field cannot be fetched because it tries to get the model using the name of the controller. This model won't exist, so throws error.

**Scenario:**
A controller is named `LocationsAliases` and uses `defaultTable` value `Locations`. The app, before this fix, will try to get the entity of `LocationsAliases`, instead of `Locations`.